### PR TITLE
git_ignoreやり直し

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,6 @@
 yarn-debug.log*
 .yarn-integrity
 
-.env
+/.env
 /public/uploads
-vendor/bundle
+/vendor/bundle


### PR DESCRIPTION
ファイルの指定方法間違いのためやり直し